### PR TITLE
Fixes the nersc testing issue for the run_e3sm test script

### DIFF
--- a/jenkins/cori_run_e3sm.sh
+++ b/jenkins/cori_run_e3sm.sh
@@ -2,7 +2,7 @@
 
 # boiler: every script must have these three lines
 export SCRIPTROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
-export CIME_MACHINE=edison
+export CIME_MACHINE=cori-knl
 source $SCRIPTROOT/util/setup_common.sh
 
-source $SCRIPTROOT/util/run_acme_test.sh
+source $SCRIPTROOT/util/run_e3sm_test.sh

--- a/jenkins/edison_run_e3sm.sh
+++ b/jenkins/edison_run_e3sm.sh
@@ -2,7 +2,7 @@
 
 # boiler: every script must have these three lines
 export SCRIPTROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
-export CIME_MACHINE=cori-knl
+export CIME_MACHINE=edison
 source $SCRIPTROOT/util/setup_common.sh
 
-source $SCRIPTROOT/util/run_acme_test.sh
+source $SCRIPTROOT/util/run_e3sm_test.sh

--- a/jenkins/skybridge_run_e3sm.sh
+++ b/jenkins/skybridge_run_e3sm.sh
@@ -7,4 +7,4 @@ source $SCRIPTROOT/util/setup_common.sh
 
 git config --global http.proxy $http_proxy
 
-source $SCRIPTROOT/util/run_acme_test.sh
+source $SCRIPTROOT/util/run_e3sm_test.sh

--- a/util/run_e3sm_ctest/runE3smTest_template.sh
+++ b/util/run_e3sm_ctest/runE3smTest_template.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -xle
 # Script to test run_e3sm.template.csh
 #   Absolute path to RUN_E3SM_DIR is supplied by CMake configuration
 #   Includes Batch-system specific method for checking queue
@@ -73,7 +73,7 @@ elif [ "$batchsystem" == "pbs" ]; then
     do sleep 5
   done
 
-elif [ "$batchsystem" == "slurm" ]; then
+elif [[ "$batchsystem" == *"slurm"* ]]; then
   echo "BATCH_SYSTEM = slurm ; Waiting for batch job to finish"
   while [ `squeue -j ${jobid} | wc -l` -eq 2 ]
     do sleep 5

--- a/util/run_e3sm_test.sh
+++ b/util/run_e3sm_test.sh
@@ -1,5 +1,4 @@
 
-
 cd ${SCRIPTROOT}/util/run_e3sm_ctest
 rm -f CMakeCache.txt
 cmake . -DSITE:STRING="${CIME_MACHINE}"

--- a/util/setup_common.sh
+++ b/util/setup_common.sh
@@ -1,10 +1,25 @@
 umask 002
-export E3SMREPO=$SCRIPTROOT/../${FORCE_REPO_PATH:-ACME}
+
+if [ -z "$FORCE_REPO_PATH" ]; then
+  if [ -d $SCRIPTROOT/../ACME ]; then
+    FOUND_REPO_NAME=ACME
+  elif [ -d $SCRIPTROOT/../E3SM ]; then
+    FOUND_REPO_NAME=E3SM
+  else
+    # Not certain this is the best way to handle this...
+    echo "Could not find the E3SM repo"
+    exit 1
+  fi
+  export E3SMREPO=$SCRIPTROOT/../${FOUND_REPO_NAME}
+else
+  export E3SMREPO=$SCRIPTROOT/../${FORCE_REPO_PATH}
+fi
+
 export CIME_MODEL=e3sm
 if [ -z "$DEBUG" ]; then
-    export RUNSCRIPT=$E3SMREPO/cime/scripts/Tools/jenkins_script
+  export RUNSCRIPT=$E3SMREPO/cime/scripts/Tools/jenkins_script
 else
-    export RUNSCRIPT="echo $E3SMREPO/cime/scripts/Tools/jenkins_script"
+  export RUNSCRIPT="echo $E3SMREPO/cime/scripts/Tools/jenkins_script"
 fi
 chmod -R a+rX $E3SMREPO || echo "Some chmods failed"
 
@@ -13,5 +28,5 @@ chmod -R a+rX $E3SMREPO || echo "Some chmods failed"
 
 machine_custom_setup=$SCRIPTROOT/util/${CIME_MACHINE}_setup.sh
 if [ -e $machine_custom_setup ]; then
-    source $machine_custom_setup
+  source $machine_custom_setup
 fi


### PR DESCRIPTION
Also makes the common setup more generic regarding the E3SM repository name, and updates the test script names to `e3sm` instead of `acme`.
I tested this by running the script on cori-knl; the case finished and was reported successfully.