### PR TITLE
Fix the directory to account for the change in the grid name

### DIFF
--- a/util/run_e3sm_ctest/runE3smTest_template.sh
+++ b/util/run_e3sm_ctest/runE3smTest_template.sh
@@ -14,7 +14,7 @@ if [ ! -d "${SCRATCH}/E3SM_simulations" ]; then
   mkdir ${SCRATCH}/E3SM_simulations
 fi
 
-case_name="default.default.A_WCYCL1850_template.ne4np4_oQU240"
+case_name="default.default.A_WCYCL1850_template.ne4_oQU240"
 case_scratch="${SCRATCH}/E3SM_simulations/${case_name}"
 case_dir="${case_scratch}/case_scripts"
 public_scratch="${SCRATCH}"


### PR DESCRIPTION
The xml upgrade to V2 removed the shortname for the ne4_oQU240 grid. Using the new name in the run_e3sm script changes the case name, meaning this test needs to be fixed.