### PR TITLE
anvil reverted back to centos6, now different from blues

### DIFF
--- a/util/anvil_setup.sh
+++ b/util/anvil_setup.sh
@@ -1,1 +1,6 @@
-blues_setup.sh
+# Set up python
+export PATH=/software/python-gnu-2.7.5/bin:$PATH
+export LD_LIBRARY_PATH=/software/python-gnu-2.7.5/lib:$LD_LIBRARY_PATH
+
+# load git
+soft add +git-2.5.0


### PR DESCRIPTION
anvil nodes are using centos6 and soft keys again, while
the rest of blues are using centos7 and modules. This
commit reverts anvil to using the old system.