### PR TITLE
Update cori_atmnbfb testing to use new e3sm_simple environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,27 +3,35 @@ Test scripts for cron and jenkins jobs
 
 How it works (for Jenkins jobs):
 
-Make/modify a script in the jenkins subdirectory of this repo. The script name should be $machine_$branch_$test.
-The first code block for all the scripts should be:
+Make/modify a script in the jenkins subdirectory of this repo. The script name 
+should be `$machine_$branch_$test`. The first code block for all the 
+scripts should be:
 
+```bash
 export SCRIPTROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
 export CIME_MACHINE=$machine
 source $SCRIPTROOT/util/setup_common.sh
+```
 
-... where $machine is the e3sm machine for the test.
+where `$machine` is the E3SM machine for the test, and the lines below this 
+block are the actual test.
 
-The lines below this block are the actual test.
-
-If a util/$machine_setup.sh file exists, it will also be sourced.
+Note: If a `util/$machine_setup.sh` file exists, it will also be sourced.
 
 The test process:
 
-Jenkins will clone E3SM and E3SM_test_scripts into the top level workspace directory:
+Jenkins will clone  `E3SM` and `E3SM_test_scripts` into the top level workspace 
+directory:
+
+```bash
 % ls
 ACME
 E3SM_test_scripts
+```
+It will then just run the appropriate script for the job, for example, this is 
+skybridge job:
 
-It will then just run the appropriate script for the job, for example, this is skybridge job:
-
+```bash
 #!/bin/bash -xle
 ./E3SM_test_scripts/jenkins/skybridge_next.sh
+```

--- a/jenkins/cori_atmnbfb.sh
+++ b/jenkins/cori_atmnbfb.sh
@@ -5,5 +5,11 @@ export SCRIPTROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
 export CIME_MACHINE=cori-knl
 source $SCRIPTROOT/util/setup_common.sh
 
-module load python/2.7-anaconda-5.2
+# Unload python module from:
+# $SCRIPTROOT/util/setup_common.sh --> $SCRIPTROOT/util/${CIME_MACHINE}_setup.sh
+module unload python/2.7-anaconda-5.2
+
+# Get e3sm_simple conda env
+source /global/project/projectdirs/acme/software/anaconda_envs/load_latest_e3sm_simple.sh
+
 $RUNSCRIPT -j 2 -t e3sm_atm_nbfb -O master --baseline-compare=yes


### PR DESCRIPTION
The climate reproducibility tests being run in the `cori_atmnbfb` test suite are being refactored in [Forthcoming CIME PR] to use the [EVV](https://github.com/conda-forge/evv4esm-feedstock) conda package, which is installed in the new `e3sm_simple` conda environment. This updates the `cori_atmnbfb` jenkins job to use `e3sm_simple`.

I also updated the README a bit to use more of the available code markdown syntax. 

---
~~Still TODO~~

This is marked as a WIP because these things are required first:

- [x] Deploy `e3sm_simple` to `cori-knl`; follow progress at E3SM-Project/e3sm-unified#53
- [x] E3SM-Project/E3SM#3135 merged into E3SM

Note: The current version of the PGN test being run in the `cori_atmnbfb` test suite requires the Scikit Learn conda package but the refactored PGN will not need it (same things accomplished in numpy). So: 
* The current PGN test will break in the `e3sm_simple` environment because of the missing `scikit-learn` package
* The refactored PGN and TSC test will break in the `python/2.7-anaconda-5.2` environment currently used on `cori-knl` because of the missing `evv4esm` package. 