### PR TITLE
Use `cime_env` where avaiable

### DIFF
--- a/jenkins/cori_atmnbfb.sh
+++ b/jenkins/cori_atmnbfb.sh
@@ -10,6 +10,6 @@ source $SCRIPTROOT/util/setup_common.sh
 module unload python/2.7-anaconda-5.2
 
 # Get e3sm_simple conda env
-source /global/project/projectdirs/acme/software/anaconda_envs/load_latest_e3sm_simple.sh
+source /global/project/projectdirs/acme/software/anaconda_envs/load_latest_cime_env.sh
 
 $RUNSCRIPT -j 2 -t e3sm_atm_nbfb -O master --baseline-compare=yes

--- a/jenkins/cori_atmnbfb.sh
+++ b/jenkins/cori_atmnbfb.sh
@@ -5,11 +5,4 @@ export SCRIPTROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
 export CIME_MACHINE=cori-knl
 source $SCRIPTROOT/util/setup_common.sh
 
-# Unload python module from:
-# $SCRIPTROOT/util/setup_common.sh --> $SCRIPTROOT/util/${CIME_MACHINE}_setup.sh
-module unload python/2.7-anaconda-5.2
-
-# Get e3sm_simple conda env
-source /global/project/projectdirs/acme/software/anaconda_envs/load_latest_cime_env.sh
-
 $RUNSCRIPT -j 2 -t e3sm_atm_nbfb -O master --baseline-compare=yes

--- a/util/anvil_setup.sh
+++ b/util/anvil_setup.sh
@@ -1,6 +1,5 @@
 # Set up python
-export PATH=/software/python-gnu-2.7.5/bin:$PATH
-export LD_LIBRARY_PATH=/software/python-gnu-2.7.5/lib:$LD_LIBRARY_PATH
+source  /lcrc/soft/climate/e3sm-unified/load_latest_cime_env.sh
 
 # load git
 soft add +git-2.5.0

--- a/util/bebop_setup.sh
+++ b/util/bebop_setup.sh
@@ -1,4 +1,5 @@
+# Set up python
+source  /lcrc/soft/climate/e3sm-unified/load_latest_cime_env.sh
 
 module load cmake/3.8.1-orygmpj
 module load intel-parallel-studio/cluster.2017.4-wyg4gfu
-module load python/2.7.13-2ai3lq6

--- a/util/compy_setup.sh
+++ b/util/compy_setup.sh
@@ -1,1 +1,1 @@
-
+source /compyfs/software/e3sm-unified/load_latest_cime_env.sh

--- a/util/cori-knl_setup.sh
+++ b/util/cori-knl_setup.sh
@@ -1,1 +1,2 @@
-module load python/2.7-anaconda-5.2 git
+module load git
+source /global/project/projectdirs/acme/software/anaconda_envs/load_latest_cime_env.sh

--- a/util/theta_setup.sh
+++ b/util/theta_setup.sh
@@ -1,2 +1,4 @@
 export PROJECT=ClimateEnergy_3
 export CHARGE_ACCOUNT=ClimateEnergy_3
+
+source /lus/theta-fs0/projects/ccsm/acme/tools/e3sm-unified/load_latest_cime_env.sh


### PR DESCRIPTION
This updates the machine configuration for:

* Anvil 
* Bebop*
* Compy
* Cori
* Theta* 


*Please look at Bobop and Theta closely as I'm not 100% sure `cime_env` is available for them.*

to use the latest `cime_env` as the python environment for E3SM/CIME testing. Right now, this is needed for the external python dependencies required by the `e3sm_atm_nbfb_*` tests (currently only run on `cori-knl`) but will likely be used in the future by other CIME tests as the ability to use external python dependencies in CIME has been request broadly.

This covers all the machines in the `E3SM_Machine_Coverage` section on [CDASH](https://my.cdash.org/index.php?project=ACME_Climate), and all but `sandiatoss3` and `melvin` in the `E3SM_Baselines` section because `cime_env` isn't deployed to them (Jim, I think you'd have to deploy `cime_env` there...).

----

@xylar , once this is merged and the `e3sm_atm_nbfb_*` have run successfully, you can remove the `e3sm_simple` env. off of Cori. 

cc @mkstratos: this is how the python environment needed for EVV is deployed. 