### PR TITLE
Python 2 relapse on Cori

### DIFF
--- a/jenkins/cori_prod_maint.sh
+++ b/jenkins/cori_prod_maint.sh
@@ -5,6 +5,11 @@ export SCRIPTROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
 export CIME_MACHINE=cori-knl
 source $SCRIPTROOT/util/setup_common.sh
 
+# deactivate cime_env for python 2
+conda deactivate
+module load python/2.7-anaconda-5.2
+
+
 cd $E3SMREPO && git submodule update --init
 cd -
 $RUNSCRIPT -j 2 -t e3sm_prod --baseline-compare=yes


### PR DESCRIPTION
Moves testing on Cori back to using the python 2 module instead of `cime_env` while python 3 fixes are in the works. 