### PR TITLE
Jenkins: Performance data upload from Compy, Cori

### DIFF
--- a/jenkins/compy_pace.sh
+++ b/jenkins/compy_pace.sh
@@ -5,7 +5,7 @@
 # boiler: every script must have these three lines
 export SCRIPTROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
 export CIME_MACHINE=compy
-source $SCRIPTROOT/util/setup_common.sh
+#source $SCRIPTROOT/util/setup_common.sh
 
 # Performance archive directory on this platform
 PERF_ARCHIVE_DIR=/compyfs/performance_archive
@@ -48,19 +48,19 @@ then
 fi 
 
 curdate=$(date '+%Y_%m_%d')
-perl e3sm_perf_archive.perl > e3sm_perf_archive_compy_${curdate}_out.txt
-mv e3sm_perf_archive_compy_${curdate}_out.txt performance_archive_compy_all_${curdate}
-./pace-upload --perf-archive ./performance_archive_compy_all_${curdate}
+perl e3sm_perf_archive.perl > e3sm_perf_archive_${CIME_MACHINE}_${curdate}_out.txt
+mv e3sm_perf_archive_${CIME_MACHINE}_${curdate}_out.txt performance_archive_${CIME_MACHINE}_all_${curdate}
+./pace-upload --perf-archive ./performance_archive_${CIME_MACHINE}_all_${curdate}
 if [ $? -ne 0 ]
 then
   echo "Error: pace-upload failed. Check log."
   exit 4
 fi 
-mv pace-*.log performance_archive_compy_all_${curdate}
-tar zcf performance_archive_compy_all_${curdate}.tar.gz performance_archive_compy_all_${curdate}
+mv pace-*.log performance_archive_${CIME_MACHINE}_all_${curdate}
+tar zcf performance_archive_${CIME_MACHINE}_all_${curdate}.tar.gz performance_archive_${CIME_MACHINE}_all_${curdate}
 
 # Move processed exps into old perf data archive
 curmonth=$(date '+%Y-%m')
 mkdir -p ${OLD_PERF_ARCHIVE_DIR}/${curmonth}
-mv performance_archive_compy_all_${curdate}* ${OLD_PERF_ARCHIVE_DIR}/${curmonth}
+mv performance_archive_${CIME_MACHINE}_all_${curdate}* ${OLD_PERF_ARCHIVE_DIR}/${curmonth}
 

--- a/jenkins/compy_pace.sh
+++ b/jenkins/compy_pace.sh
@@ -1,0 +1,66 @@
+#!/bin/bash -xle
+# Purpose: Automate performance data upload to PACE
+# Author: Sarat Sreepathi (sarat@ornl.gov)
+
+# boiler: every script must have these three lines
+export SCRIPTROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
+export CIME_MACHINE=compy
+source $SCRIPTROOT/util/setup_common.sh
+
+# Performance archive directory on this platform
+PERF_ARCHIVE_DIR=/compyfs/performance_archive
+# Archives of old performance data on this platform
+OLD_PERF_ARCHIVE_DIR=/compyfs/OLD_PERF
+
+# The performance archive directory on the platform is the working dir
+cd ${PERF_ARCHIVE_DIR}
+
+if [ $? -ne 0 ]
+then
+  echo "Error:Unable to change working directory to ${PERF_ARCHIVE_DIR}"
+  exit 1
+fi 
+
+# Download PACE upload script
+# Python2 version (supported by system Python without requiring module load)
+wget -O pace-upload https://pace.ornl.gov/static/tools/pace-upload
+# Python3 version (requires Anaconda/Python module with requests package)
+#wget -O pace-upload https://pace.ornl.gov/static/tools/pace-upload3
+
+if [ $? -ne 0 ]
+then
+  echo "Error: Unable to download pace-upload script."
+  exit 2
+fi 
+
+chmod +x pace-upload
+
+# Performance archive should not contain large files (empirical threshold of 50MB)
+# List any large files 
+echo "Large file list:"
+find . -size +50M -exec ls -lh {} \;
+# Delete large files
+find . -size +50M -exec rm {} \;
+if [ $? -ne 0 ]
+then
+  echo "Error: Unable to delete large files before preparing upload package."
+  exit 3
+fi 
+
+curdate=$(date '+%Y_%m_%d')
+perl e3sm_perf_archive.perl > e3sm_perf_archive_compy_${curdate}_out.txt
+mv e3sm_perf_archive_compy_${curdate}_out.txt performance_archive_compy_all_${curdate}
+./pace-upload --perf-archive ./performance_archive_compy_all_${curdate}
+if [ $? -ne 0 ]
+then
+  echo "Error: pace-upload failed. Check log."
+  exit 4
+fi 
+mv pace-*.log performance_archive_compy_all_${curdate}
+tar zcf performance_archive_compy_all_${curdate}.tar.gz performance_archive_compy_all_${curdate}
+
+# Move processed exps into old perf data archive
+curmonth=$(date '+%Y-%m')
+mkdir -p ${OLD_PERF_ARCHIVE_DIR}/${curmonth}
+mv performance_archive_compy_all_${curdate}* ${OLD_PERF_ARCHIVE_DIR}/${curmonth}
+

--- a/jenkins/compy_pace.sh
+++ b/jenkins/compy_pace.sh
@@ -8,59 +8,9 @@ export CIME_MACHINE=compy
 #source $SCRIPTROOT/util/setup_common.sh
 
 # Performance archive directory on this platform
-PERF_ARCHIVE_DIR=/compyfs/performance_archive
+export PERF_ARCHIVE_DIR=/compyfs/performance_archive
 # Archives of old performance data on this platform
-OLD_PERF_ARCHIVE_DIR=/compyfs/OLD_PERF
+export OLD_PERF_ARCHIVE_DIR=${PERF_ARCHIVE_DIR}/../OLD_PERF
 
-# The performance archive directory on the platform is the working dir
-cd ${PERF_ARCHIVE_DIR}
-
-if [ $? -ne 0 ]
-then
-  echo "Error:Unable to change working directory to ${PERF_ARCHIVE_DIR}"
-  exit 1
-fi 
-
-# Download PACE upload script
-# Python2 version (supported by system Python without requiring module load)
-wget -O pace-upload https://pace.ornl.gov/static/tools/pace-upload
-# Python3 version (requires Anaconda/Python module with requests package)
-#wget -O pace-upload https://pace.ornl.gov/static/tools/pace-upload3
-
-if [ $? -ne 0 ]
-then
-  echo "Error: Unable to download pace-upload script."
-  exit 2
-fi 
-
-chmod +x pace-upload
-
-# Performance archive should not contain large files (empirical threshold of 50MB)
-# List any large files 
-echo "Large file list:"
-find . -size +50M -exec ls -lh {} \;
-# Delete large files
-find . -size +50M -exec rm {} \;
-if [ $? -ne 0 ]
-then
-  echo "Error: Unable to delete large files before preparing upload package."
-  exit 3
-fi 
-
-curdate=$(date '+%Y_%m_%d')
-perl e3sm_perf_archive.perl > e3sm_perf_archive_${CIME_MACHINE}_${curdate}_out.txt
-mv e3sm_perf_archive_${CIME_MACHINE}_${curdate}_out.txt performance_archive_${CIME_MACHINE}_all_${curdate}
-./pace-upload --perf-archive ./performance_archive_${CIME_MACHINE}_all_${curdate}
-if [ $? -ne 0 ]
-then
-  echo "Error: pace-upload failed. Check log."
-  exit 4
-fi 
-mv pace-*.log performance_archive_${CIME_MACHINE}_all_${curdate}
-tar zcf performance_archive_${CIME_MACHINE}_all_${curdate}.tar.gz performance_archive_${CIME_MACHINE}_all_${curdate}
-
-# Move processed exps into old perf data archive
-curmonth=$(date '+%Y-%m')
-mkdir -p ${OLD_PERF_ARCHIVE_DIR}/${curmonth}
-mv performance_archive_${CIME_MACHINE}_all_${curdate}* ${OLD_PERF_ARCHIVE_DIR}/${curmonth}
+source $SCRIPTROOT/util/pace_archive.sh
 

--- a/jenkins/cori_pace.sh
+++ b/jenkins/cori_pace.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -xle
+# Purpose: Automate performance data upload to PACE
+# Author: Sarat Sreepathi (sarat@ornl.gov)
+
+# boiler: every script must have these three lines
+export SCRIPTROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
+export CIME_MACHINE=cori
+#source $SCRIPTROOT/util/setup_common.sh
+
+# Performance archive directory on this platform
+PERF_ARCHIVE_DIR=/global/cfs/cdirs/e3sm/performance_archive
+# Archives of old performance data on this platform
+export OLD_PERF_ARCHIVE_DIR=${PERF_ARCHIVE_DIR}/../OLD_PERF
+
+export PACE_PYTHON3=1
+source $SCRIPTROOT/util/pace_archive.sh
+

--- a/util/pace_archive.sh
+++ b/util/pace_archive.sh
@@ -5,10 +5,15 @@
 cd ${PERF_ARCHIVE_DIR}
 
 # Download PACE upload script
-# Python2 version (supported by system Python without requiring module load)
-wget -O pace-upload https://pace.ornl.gov/static/tools/pace-upload
-# Python3 version (requires Anaconda/Python module with requests package)
-#wget -O pace-upload https://pace.ornl.gov/static/tools/pace-upload3
+if [[ -z "${PACE_PYTHON3}" ]] ; then
+	# Python2 version (supported by system Python without requiring module load)
+	echo "PACE Python 2"
+	wget -O pace-upload https://pace.ornl.gov/static/tools/pace-upload
+else
+	# Python3 version (requires Anaconda/Python module with requests package)
+	echo "PACE Python 3"
+	wget -O pace-upload https://pace.ornl.gov/static/tools/pace-upload3
+fi
 
 chmod +x pace-upload
 

--- a/util/pace_archive.sh
+++ b/util/pace_archive.sh
@@ -1,0 +1,38 @@
+# Purpose: Automate performance data upload to PACE
+# Author: Sarat Sreepathi (sarat@ornl.gov)
+
+# The performance archive directory on the platform is the working dir
+cd ${PERF_ARCHIVE_DIR}
+
+# Download PACE upload script
+# Python2 version (supported by system Python without requiring module load)
+wget -O pace-upload https://pace.ornl.gov/static/tools/pace-upload
+# Python3 version (requires Anaconda/Python module with requests package)
+#wget -O pace-upload https://pace.ornl.gov/static/tools/pace-upload3
+
+chmod +x pace-upload
+
+# Performance archive should not contain large files (empirical threshold of 50MB)
+# List any large files 
+echo "Large file list:"
+find . -size +50M -exec ls -lh {} \;
+# Delete large files
+find . -size +50M -exec rm {} \;
+
+curdate=$(date '+%Y_%m_%d')
+perl e3sm_perf_archive.perl > e3sm_perf_archive_${CIME_MACHINE}_${curdate}_out.txt
+mv e3sm_perf_archive_${CIME_MACHINE}_${curdate}_out.txt performance_archive_${CIME_MACHINE}_all_${curdate}
+./pace-upload --perf-archive ./performance_archive_${CIME_MACHINE}_all_${curdate}
+if [ $? -ne 0 ]
+then
+  echo "Error: pace-upload failed. Check log."
+  exit 4
+fi 
+mv pace-*.log performance_archive_${CIME_MACHINE}_all_${curdate}
+tar zcf performance_archive_${CIME_MACHINE}_all_${curdate}.tar.gz performance_archive_${CIME_MACHINE}_all_${curdate}
+
+# Move processed exps into old perf data archive
+curmonth=$(date '+%Y-%m')
+mkdir -p ${OLD_PERF_ARCHIVE_DIR}/${curmonth}
+mv performance_archive_${CIME_MACHINE}_all_${curdate}* ${OLD_PERF_ARCHIVE_DIR}/${curmonth}
+

--- a/util/pace_archive.sh
+++ b/util/pace_archive.sh
@@ -1,6 +1,9 @@
 # Purpose: Automate performance data upload to PACE
 # Author: Sarat Sreepathi (sarat@ornl.gov)
 
+# Allow group write permission for any files generated
+umask 002 
+
 # The performance archive directory on the platform is the working dir
 cd ${PERF_ARCHIVE_DIR}
 

--- a/util/pace_archive.sh
+++ b/util/pace_archive.sh
@@ -28,11 +28,7 @@ curdate=$(date '+%Y_%m_%d')
 perl e3sm_perf_archive.perl > e3sm_perf_archive_${CIME_MACHINE}_${curdate}_out.txt
 mv e3sm_perf_archive_${CIME_MACHINE}_${curdate}_out.txt performance_archive_${CIME_MACHINE}_all_${curdate}
 ./pace-upload --perf-archive ./performance_archive_${CIME_MACHINE}_all_${curdate}
-if [ $? -ne 0 ]
-then
-  echo "Error: pace-upload failed. Check log."
-  exit 4
-fi 
+
 mv pace-*.log performance_archive_${CIME_MACHINE}_all_${curdate}
 tar zcf performance_archive_${CIME_MACHINE}_all_${curdate}.tar.gz performance_archive_${CIME_MACHINE}_all_${curdate}
 


### PR DESCRIPTION
This script facilitates automatic data upload from Compy's
performance archive into PACE.

It requires the Jenkins user to run this manually the first time
to use the Github credentials to create an authorized token for
later uploads automatically.

It stores the token information in $HOME/.pacecc.

It does not require cloning of E3SM sources or builds.

It moves certain files from the machine's PERF_ARCHIVE_DIR to the
older (OLD_PERF_ARCHIVE_DIR) after data is processed.

It deletes very large files (>50MB) that are not meant to be placed in the
performance archive by design.

**Testing:** 
Successfully uploaded performance data from Compy by commenting out the boilerplate initialization. 
```#source $SCRIPTROOT/util/setup_common.sh```
I didn't load any Python module, system Python was sufficient. In case of Python environment issues, just unload any custom Python envs.


