### PR TITLE
PACE archiving: minor mods

### DIFF
--- a/jenkins/anvil_pace.sh
+++ b/jenkins/anvil_pace.sh
@@ -11,6 +11,8 @@ export CIME_MACHINE=anvil
 export PERF_ARCHIVE_DIR=/lcrc/group/acme/performance_archive
 # Archives of old performance data on this platform
 export OLD_PERF_ARCHIVE_DIR=${PERF_ARCHIVE_DIR}/../OLD_PERF
+# Following tag is used by the Perl script in naming the perf. archive directory
+export PROJ_SPACE_TAG=acme
 
 module load requests/2.20.1
 source $SCRIPTROOT/util/pace_archive.sh

--- a/jenkins/compy_pace.sh
+++ b/jenkins/compy_pace.sh
@@ -11,6 +11,8 @@ export CIME_MACHINE=compy
 export PERF_ARCHIVE_DIR=/compyfs/performance_archive
 # Archives of old performance data on this platform
 export OLD_PERF_ARCHIVE_DIR=${PERF_ARCHIVE_DIR}/../OLD_PERF
+# Following tag is used by the Perl script in naming the perf. archive directory
+export PROJ_SPACE_TAG=all
 
 source $SCRIPTROOT/util/pace_archive.sh
 

--- a/jenkins/cori_pace.sh
+++ b/jenkins/cori_pace.sh
@@ -11,6 +11,8 @@ export CIME_MACHINE=cori
 PERF_ARCHIVE_DIR=/global/cfs/cdirs/e3sm/performance_archive
 # Archives of old performance data on this platform
 export OLD_PERF_ARCHIVE_DIR=${PERF_ARCHIVE_DIR}/../OLD_PERF
+# Following tag is used by the Perl script in naming the perf. archive directory
+export PROJ_SPACE_TAG=e3sm
 
 export PACE_PYTHON3=1
 source $SCRIPTROOT/util/pace_archive.sh

--- a/jenkins/theta_pace.sh
+++ b/jenkins/theta_pace.sh
@@ -11,6 +11,8 @@ export CIME_MACHINE=theta
 export PERF_ARCHIVE_DIR=/projects/ClimateEnergy_4/performance_archive
 # Archives of old performance data on this platform
 export OLD_PERF_ARCHIVE_DIR=${PERF_ARCHIVE_DIR}/../OLD_PERF
+# Following tag is used by the Perl script in naming the perf. archive directory
+export PROJ_SPACE_TAG=ClimateEnergy_4
 
 source $SCRIPTROOT/util/pace_archive.sh
 

--- a/util/pace_archive.sh
+++ b/util/pace_archive.sh
@@ -32,7 +32,11 @@ perl e3sm_perf_archive.perl > e3sm_perf_archive_${CIME_MACHINE}_${curdate}_out.t
 mv e3sm_perf_archive_${CIME_MACHINE}_${curdate}_out.txt performance_archive_${CIME_MACHINE}_all_${curdate}
 ./pace-upload --perf-archive ./performance_archive_${CIME_MACHINE}_all_${curdate}
 
-mv pace-*.log performance_archive_${CIME_MACHINE}_all_${curdate}
+if stat -t pace-*.log >/dev/null 2>&1
+then
+	mv pace-*.log performance_archive_${CIME_MACHINE}_all_${curdate}
+fi
+
 tar zcf performance_archive_${CIME_MACHINE}_all_${curdate}.tar.gz performance_archive_${CIME_MACHINE}_all_${curdate}
 
 # Move processed exps into old perf data archive


### PR DESCRIPTION
Various minor modificationsi:
* Use PROJ_SPACE_TAG in directory creation.
* Download Perl script from PACE server for consistency
* Avoid mv error when log file doesn't exist (when no exps
	need to be uploaded)
* Add begin, completion messages
* Skip tar.gz creation to minimize time.

