### PR TITLE
PACE archiving on Theta: Switch to Python 3

### DIFF
--- a/jenkins/theta_pace.sh
+++ b/jenkins/theta_pace.sh
@@ -14,5 +14,8 @@ export OLD_PERF_ARCHIVE_DIR=${PERF_ARCHIVE_DIR}/../OLD_PERF
 # Following tag is used by the Perl script in naming the perf. archive directory
 export PROJ_SPACE_TAG=ClimateEnergy_4
 
+# Switch to Python 3 version
+export PACE_PYTHON3=1
+
 source $SCRIPTROOT/util/pace_archive.sh
 


### PR DESCRIPTION
Due to recent environment upgrade on Theta, switch to Python 3 version
of the PACE uploader is required.

Please merge asap as nightly upload requires this change.