### PR TITLE
PACE: Add Chrysalis support and finegrain timestamps to archive directories

### DIFF
--- a/jenkins/anvil_pace.sh
+++ b/jenkins/anvil_pace.sh
@@ -8,11 +8,11 @@ export CIME_MACHINE=anvil
 #source $SCRIPTROOT/util/setup_common.sh
 
 # Performance archive directory on this platform
-export PERF_ARCHIVE_DIR=/lcrc/group/acme/performance_archive
+export PERF_ARCHIVE_DIR=/lcrc/group/e3sm/performance_archive
 # Archives of old performance data on this platform
 export OLD_PERF_ARCHIVE_DIR=${PERF_ARCHIVE_DIR}/../OLD_PERF
 # Following tag is used by the Perl script in naming the perf. archive directory
-export PROJ_SPACE_TAG=acme
+export PROJ_SPACE_TAG=e3sm
 
 module load requests/2.20.1
 source $SCRIPTROOT/util/pace_archive.sh

--- a/jenkins/chrysalis_pace.sh
+++ b/jenkins/chrysalis_pace.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -xle
+# Purpose: Automate performance data upload to PACE
+# Author: Sarat Sreepathi (sarat@ornl.gov)
+
+# boiler: every script must have these three lines
+export SCRIPTROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
+export CIME_MACHINE=chrysalis
+#source $SCRIPTROOT/util/setup_common.sh
+
+# Performance archive directory on this platform
+export PERF_ARCHIVE_DIR=/lcrc/group/e3sm/PERF_Chrysalis/performance_archive
+# Archives of old performance data on this platform
+export OLD_PERF_ARCHIVE_DIR=${PERF_ARCHIVE_DIR}/../OLD_PERF
+# Following tag is used by the Perl script in naming the perf. archive directory
+export PROJ_SPACE_TAG=e3sm
+
+module load anaconda3/2020.11
+export PACE_PYTHON3=1
+source $SCRIPTROOT/util/pace_archive.sh
+

--- a/util/pace_archive.sh
+++ b/util/pace_archive.sh
@@ -30,8 +30,8 @@ find . -size +50M -exec ls -lh {} \; > large-files-removed.txt
 find . -size +50M -exec rm {} \;
 
 wget -O e3sm_perf_archive.perl https://pace.ornl.gov/static/tools/e3sm_perf_archive.perl
-curdate=$(date '+%Y_%m_%d')
-perl e3sm_perf_archive.perl > e3sm_perf_archive_${CIME_MACHINE}_${curdate}_out.txt
+curdate=$(date '+%Y_%m_%d_%H_%M_%S')
+perl e3sm_perf_archive.perl --timestamp ${curdate} > e3sm_perf_archive_${CIME_MACHINE}_${curdate}_out.txt
 mv e3sm_perf_archive_${CIME_MACHINE}_${curdate}_out.txt performance_archive_${CIME_MACHINE}_${PROJ_SPACE_TAG}_${curdate}
 ./pace-upload --perf-archive ./performance_archive_${CIME_MACHINE}_${PROJ_SPACE_TAG}_${curdate}
 


### PR DESCRIPTION
Add hh_mm_ss to timestamps for directory creation. Avoids issues with tasks run at data change boundaries.
Switch acme to e3sm in filepaths.