### PR TITLE
Remove non-python setup from a number of machine setup scripts

### DIFF
--- a/util/anvil_setup.sh
+++ b/util/anvil_setup.sh
@@ -4,6 +4,4 @@ source  /lcrc/soft/climate/e3sm-unified/load_latest_cime_env.sh
 source /home/software/spack-0.10.1/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lmod-7.4.9-ic63herzfgw5u3na5mdtvp3nwxy6oj2z/lmod/lmod/init/sh
 export MODULEPATH=$MODULEPATH:/software/centos7/spack-latest/share/spack/lmod/linux-centos7-x86_64/Core
 
-module load intel/17.0.0-pwabdn2 cmake/3.14.2-gvwazz3 git/2.13.0
-
 export TERM=xterm

--- a/util/ascent_setup.sh
+++ b/util/ascent_setup.sh
@@ -3,4 +3,4 @@ source /sw/ascent/lmod/7.8.2/rhel7.5_4.8.5/lmod/lmod/init/sh
 
 export MODULEPATH=/sw/ascent/modulefiles/20180914/site/linux-rhel7-ppc64le/Core:/sw/ascent/modulefiles/core
 
-module load python/3.7.0 git/2.13.0 cmake/3.13.4
+module load python/3.7.0

--- a/util/bebop_setup.sh
+++ b/util/bebop_setup.sh
@@ -1,5 +1,2 @@
 # Set up python
 source  /lcrc/soft/climate/e3sm-unified/load_latest_cime_env.sh
-
-module load cmake/3.8.1-orygmpj
-module load intel-parallel-studio/cluster.2017.4-wyg4gfu

--- a/util/blues_setup.sh
+++ b/util/blues_setup.sh
@@ -3,5 +3,3 @@ source  /lcrc/soft/climate/e3sm-unified/load_latest_cime_env.sh
 
 source /home/software/spack-0.10.1/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lmod-7.4.9-ic63herzfgw5u3na5mdtvp3nwxy6oj2z/lmod/lmod/init/sh
 export MODULEPATH=/software/centos7/spack-latest/share/spack/lmod/linux-centos7-x86_64/Core:/soft/bebop/modulefiles
-
-module load cmake/3.14.2-gvwazz3 git/2.13.0

--- a/util/chrysalis_setup.sh
+++ b/util/chrysalis_setup.sh
@@ -2,6 +2,3 @@
 source  /lcrc/soft/climate/e3sm-unified/load_latest_cime_env.sh
 
 source /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/lmod-8.3-5be73rg/lmod/lmod/init/sh
-
-# kokkos needs CMake 3.16 or higher. Default version is 3.11.4
-module load cmake/3.19.1-yisciec

--- a/util/compy_setup.sh
+++ b/util/compy_setup.sh
@@ -1,5 +1,2 @@
 source /share/apps/E3SM/conda_envs/load_latest_cime_env.sh
 ulimit -c 0
-
-# kokkos needs CMake 3.16 or higher.
-module load cmake/3.19.6

--- a/util/cori-knl_setup.sh
+++ b/util/cori-knl_setup.sh
@@ -1,2 +1,1 @@
-module load git cmake/3.20.2
 source /global/project/projectdirs/e3sm/software/anaconda_envs/load_latest_cime_env.sh

--- a/util/mappy_setup.sh
+++ b/util/mappy_setup.sh
@@ -3,7 +3,9 @@ if [ -z "$SEMS_MODULEFILES_ROOT" ]; then
     source /projects/sems/modulefiles/utils/sems-modules-init.sh
 fi
 
-module load sems-git sems-cmake/3.12.2 sems-python/3.5.2 sems-pylint
+# We only need cmake here because mappy run cime standalone tests which
+# do not load the CIME env before running cmake
+module load sems-git sems-cmake/3.19.1 sems-python/3.5.2 sems-pylint
 
 export http_proxy=http://proxy.sandia.gov:80
 export RSYNC_PROXY=proxy.sandia.gov:80

--- a/util/theta_setup.sh
+++ b/util/theta_setup.sh
@@ -2,5 +2,3 @@ export PROJECT=ClimateEnergy_4
 export CHARGE_ACCOUNT=ClimateEnergy_4
 
 source /lus/theta-fs0/projects/ccsm/acme/tools/e3sm-unified/load_latest_cime_env.sh
-
-module load cmake/3.18.0


### PR DESCRIPTION
CIME only requires python to run. Loading anything else in these
files is misleading because the first thing CIME does on many machines
is a module purge, so loading cmake, compilers, or other things here has no impact
on what CIME actually uses on the code.