### PR TITLE
Update location for cime-env on Cori

### DIFF
--- a/util/cori-knl_setup.sh
+++ b/util/cori-knl_setup.sh
@@ -1,1 +1,1 @@
-source /global/project/projectdirs/e3sm/software/anaconda_envs/load_latest_cime_env.sh
+source /global/common/software/e3sm/anaconda_envs/load_latest_cime_env.sh


### PR DESCRIPTION
A new version of cime-env was just deployed.  It is in a new location on Cori -- the same as the latest E3SM-Unified.