### PR TITLE
Update perlmutter scream jenkins scripts

### DIFF
--- a/jenkins/perlmutter_cpu_scream.sh
+++ b/jenkins/perlmutter_cpu_scream.sh
@@ -2,9 +2,9 @@
 
 # boiler: every script must have these three lines
 export SCRIPTROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
-export CIME_MACHINE=perlmutter
+export CIME_MACHINE=pm-cpu
 export SCREAM_MACHINE=$CIME_MACHINE
 source $SCRIPTROOT/util/setup_common.sh
 
 declare -i fails=0
-$RUNSCRIPT -t e3sm_scream_v1_medres --compiler=gnugpu
+$RUNSCRIPT -t e3sm_scream_v1_medres --compiler=gnu

--- a/jenkins/perlmutter_gpu_scream.sh
+++ b/jenkins/perlmutter_gpu_scream.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -xle
+
+# boiler: every script must have these three lines
+export SCRIPTROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
+export CIME_MACHINE=pm-gpu
+export SCREAM_MACHINE=$CIME_MACHINE
+source $SCRIPTROOT/util/setup_common.sh
+
+declare -i fails=0
+$RUNSCRIPT -t e3sm_scream_v1_medres --compiler=gnugpu


### PR DESCRIPTION
Since Perlmutter has been split into two machines in config_machines, change machine name, and create two separate scripts, one for gpu and one for cpu builds/tests.