### PR TITLE
Crusher: Add test template for Omega repo

### DIFF
--- a/jenkins/crusher_omega.sh
+++ b/jenkins/crusher_omega.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -xle
+
+# boiler: every script must have these three lines
+export SCRIPTROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
+export CIME_MACHINE=crusher
+export FORCE_REPO_PATH=Omega
+source $SCRIPTROOT/util/setup_common.sh
+
+exit_code=0
+$RUNSCRIPT -j 4 -t e3sm_gpuacc $1 || exit_code=1
+
+exit $exit_code


### PR DESCRIPTION
Setting up a template for Omega development. Presently, just exercises some OpenACC tests. Would change/update test suite in the future.  