### PR TITLE
PACE on Compy: Switch to Python3

### DIFF
--- a/jenkins/compy_pace.sh
+++ b/jenkins/compy_pace.sh
@@ -14,5 +14,8 @@ export OLD_PERF_ARCHIVE_DIR=${PERF_ARCHIVE_DIR}/../OLD_PERF
 # Following tag is used by the Perl script in naming the perf. archive directory
 export PROJ_SPACE_TAG=all
 
+module load python/anaconda3-2020.02
+export PACE_PYTHON3=1
+
 source $SCRIPTROOT/util/pace_archive.sh
 


### PR DESCRIPTION
Switching to Python 3 for better filesystem traversal performance for PACE upload.