### PR TITLE
Add pes-file arg pointing to config_pes_tests.xml

### DIFF
--- a/jenkins/chrysalis_atmnbfb.sh
+++ b/jenkins/chrysalis_atmnbfb.sh
@@ -5,4 +5,4 @@ export SCRIPTROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
 export CIME_MACHINE=chrysalis
 source $SCRIPTROOT/util/setup_common.sh
 
-$RUNSCRIPT -j 4 -t e3sm_atm_nbfb -O master --baseline-compare --ignore-memleak
+$RUNSCRIPT -j 4 -t e3sm_atm_nbfb -O master --baseline-compare --ignore-memleak --pes-file $E3SMREPO/cime_config/testmods_dirs/config_pes_tests.xml


### PR DESCRIPTION
A smaller pes layout was added to config_pes_tests, this points the nightly chrysalis non-bfb tests to use that file
See: https://github.com/E3SM-Project/E3SM/pull/6030