### PR TITLE
Add cron scripts for Polaris nightly tests.

### DIFF
--- a/cron/polaris_aurora_cron.sh
+++ b/cron/polaris_aurora_cron.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
+# top directory of all Polaris cronjob work
+export POLARIS_CRON_ROOT="/lus/flare/projects/$PROJECT/$USER/polaris_scratch/cron"
+
+mkdir -p $POLARIS_CRON_ROOT
+
+# launch polaris cronjob
+exec bash $HERE/polaris_cron.sh

--- a/cron/polaris_aurora_cron.sh
+++ b/cron/polaris_aurora_cron.sh
@@ -3,7 +3,7 @@
 HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 
 # top directory of all Polaris cronjob work
-export POLARIS_CRON_ROOT="/lus/flare/projects/$PROJECT/$USER/polaris_scratch/cron"
+export POLARIS_CRON_ROOT="/lus/flare/projects/E3SM_Dec/$USER/polaris_scratch/cron"
 
 mkdir -p $POLARIS_CRON_ROOT
 

--- a/cron/polaris_chrysalis_cron.sh
+++ b/cron/polaris_chrysalis_cron.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
+# top directory of all Polaris cronjob work
+export POLARIS_CRON_ROOT="/lcrc/group/e3sm/$USER/scratch/cron"
+
+mkdir -p $POLARIS_CRON_ROOT
+
+# launch polaris cronjob
+exec bash $HERE/polaris_cron.sh

--- a/cron/polaris_cron.sh
+++ b/cron/polaris_cron.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Configuration
+export POLARIS_ROOT=$POLARIS_CRON_ROOT/polaris
+REMOTE_URL="https://github.com/E3SM-Project/polaris.git"
+BRANCH="main"
+
+# Check existence and handle repository state
+if [ ! -d "$POLARIS_ROOT/.git" ]; then
+    echo "Repository not found. Cloning..."
+    git clone -b "$BRANCH" "$REMOTE_URL" "$POLARIS_ROOT"
+    cd "$POLARIS_ROOT" || exit
+else
+    echo "Repository exists. Updating to latest remote state..."
+    cd "$POLARIS_ROOT" || exit
+    
+    # Ensure we are on the correct branch and sync with origin
+    git fetch origin
+    git checkout "$BRANCH"
+    git reset --hard "origin/$BRANCH"
+fi
+
+# Update specific submodules recursively
+echo "Updating submodules..."
+git submodule update --init --recursive jigsaw-python
+git submodule update --init e3sm_submodules/Omega
+pushd e3sm_submodules/Omega
+git submodule update --init --recursive externals/ekat externals/scorpio cime components/omega/external
+popd
+
+# Launch the final script with all passed arguments
+LAUNCH_SCRIPT="$POLARIS_ROOT/cron-scripts/launch_all.sh"
+
+if [ -f "$LAUNCH_SCRIPT" ]; then
+    echo "Launching: $LAUNCH_SCRIPT $*"
+    exec bash "$LAUNCH_SCRIPT" "$@"
+else
+    echo "Error: Launch script not found at $LAUNCH_SCRIPT"
+    exit 1
+fi

--- a/cron/polaris_cron.sh
+++ b/cron/polaris_cron.sh
@@ -2,23 +2,15 @@
 
 # Configuration
 export POLARIS_ROOT=$POLARIS_CRON_ROOT/polaris
-REMOTE_URL="https://github.com/E3SM-Project/polaris.git"
-BRANCH="main"
+#REMOTE_URL="https://github.com/E3SM-Project/polaris.git"
+#BRANCH="main"
+REMOTE_URL="https://github.com/grnydawn/polaris.git"
+BRANCH="ykim/copilot/cron-scripts"
 
-# Check existence and handle repository state
-if [ ! -d "$POLARIS_ROOT/.git" ]; then
-    echo "Repository not found. Cloning..."
-    git clone -b "$BRANCH" "$REMOTE_URL" "$POLARIS_ROOT"
-    cd "$POLARIS_ROOT" || exit
-else
-    echo "Repository exists. Updating to latest remote state..."
-    cd "$POLARIS_ROOT" || exit
-    
-    # Ensure we are on the correct branch and sync with origin
-    git fetch origin
-    git checkout "$BRANCH"
-    git reset --hard "origin/$BRANCH"
-fi
+rm -rf ${POLARIS_ROOT}
+
+git clone -b "$BRANCH" "$REMOTE_URL" "$POLARIS_ROOT"
+cd "$POLARIS_ROOT" || exit
 
 # Update specific submodules recursively
 echo "Updating submodules..."

--- a/cron/polaris_cron.sh
+++ b/cron/polaris_cron.sh
@@ -2,10 +2,8 @@
 
 # Configuration
 export POLARIS_ROOT=$POLARIS_CRON_ROOT/polaris
-#REMOTE_URL="https://github.com/E3SM-Project/polaris.git"
-#BRANCH="main"
-REMOTE_URL="https://github.com/grnydawn/polaris.git"
-BRANCH="ykim/cron-scripts"
+REMOTE_URL="https://github.com/E3SM-Project/polaris.git"
+BRANCH="main"
 
 rm -rf ${POLARIS_ROOT}
 

--- a/cron/polaris_cron.sh
+++ b/cron/polaris_cron.sh
@@ -2,8 +2,10 @@
 
 # Configuration
 export POLARIS_ROOT=$POLARIS_CRON_ROOT/polaris
-REMOTE_URL="https://github.com/E3SM-Project/polaris.git"
-BRANCH="main"
+#REMOTE_URL="https://github.com/E3SM-Project/polaris.git"
+#BRANCH="main"
+REMOTE_URL="https://github.com/grnydawn/polaris.git"
+BRANCH="ykim/chrysalis"
 
 rm -rf ${POLARIS_ROOT}
 

--- a/cron/polaris_cron.sh
+++ b/cron/polaris_cron.sh
@@ -5,7 +5,7 @@ export POLARIS_ROOT=$POLARIS_CRON_ROOT/polaris
 #REMOTE_URL="https://github.com/E3SM-Project/polaris.git"
 #BRANCH="main"
 REMOTE_URL="https://github.com/grnydawn/polaris.git"
-BRANCH="ykim/copilot/cron-scripts"
+BRANCH="ykim/cron-scripts"
 
 rm -rf ${POLARIS_ROOT}
 

--- a/cron/polaris_frontier_cron.sh
+++ b/cron/polaris_frontier_cron.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
+# top directory of all Polaris cronjob work
+export POLARIS_CRON_ROOT="/lustre/orion/cli115/proj-shared/$ENV{USER}/polaris_scratch/cron"
+
+mkdir -p $POLARIS_CRON_ROOT
+
+# launch polaris cronjob
+exec bash $HERE/polaris_cron.sh

--- a/cron/polaris_frontier_cron.sh
+++ b/cron/polaris_frontier_cron.sh
@@ -3,7 +3,7 @@
 HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 
 # top directory of all Polaris cronjob work
-export POLARIS_CRON_ROOT="/lustre/orion/cli115/proj-shared/$ENV{USER}/polaris_scratch/cron"
+export POLARIS_CRON_ROOT="/lustre/orion/cli115/proj-shared/${USER}/polaris_scratch/cron"
 
 mkdir -p $POLARIS_CRON_ROOT
 

--- a/cron/polaris_frontier_cron.sh
+++ b/cron/polaris_frontier_cron.sh
@@ -2,8 +2,16 @@
 
 HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 
+source /etc/bash.bashrc
+
 # top directory of all Polaris cronjob work
-export POLARIS_CRON_ROOT="/lustre/orion/cli115/proj-shared/${USER}/polaris_scratch/cron"
+export POLARIS_CRON_ROOT="/lustre/orion/cli115/proj-shared/$USER/polaris_scratch/cron"
+
+export all_proxy=socks://proxy.ccs.ornl.gov:3128/
+export ftp_proxy=ftp://proxy.ccs.ornl.gov:3128/
+export http_proxy=http://proxy.ccs.ornl.gov:3128/
+export https_proxy=http://proxy.ccs.ornl.gov:3128/
+export no_proxy='localhost,127.0.0.0/8,*.ccs.ornl.gov'
 
 mkdir -p $POLARIS_CRON_ROOT
 

--- a/cron/polaris_frontier_cron.sh
+++ b/cron/polaris_frontier_cron.sh
@@ -2,6 +2,7 @@
 
 HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 
+source /etc/profile
 source /etc/bash.bashrc
 
 # top directory of all Polaris cronjob work

--- a/cron/polaris_pm-cpu_cron.sh
+++ b/cron/polaris_pm-cpu_cron.sh
@@ -8,4 +8,4 @@ export POLARIS_CRON_ROOT="$PSCRATCH/polaris_scratch/cron/pm-cpu"
 mkdir -p $POLARIS_CRON_ROOT
 
 # launch polaris cronjob
-exec bash $HERE/polaris_cron.sh
+exec bash $HERE/polaris_cron.sh -m pm-cpu

--- a/cron/polaris_pm-cpu_cron.sh
+++ b/cron/polaris_pm-cpu_cron.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
+# top directory of all Polaris cronjob work
+export POLARIS_CRON_ROOT="$PSCRATCH/polaris_scratch/cron/pm-cpu"
+
+mkdir -p $POLARIS_CRON_ROOT
+
+# launch polaris cronjob
+exec bash $HERE/polaris_cron.sh

--- a/cron/polaris_pm-gpu_cron.sh
+++ b/cron/polaris_pm-gpu_cron.sh
@@ -7,5 +7,10 @@ export POLARIS_CRON_ROOT="$PSCRATCH/polaris_scratch/cron/pm-gpu"
 
 mkdir -p $POLARIS_CRON_ROOT
 
+if [[ ! -z "${SLURM_MEM_PER_CPU}" ]]; then
+unset SLURM_MEM_PER_CPU
+unset SLURM_OPEN_MODE
+fi
+
 # launch polaris cronjob
 exec bash $HERE/polaris_cron.sh -m pm-gpu

--- a/cron/polaris_pm-gpu_cron.sh
+++ b/cron/polaris_pm-gpu_cron.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
+# top directory of all Polaris cronjob work
+export POLARIS_CRON_ROOT="$PSCRATCH/polaris_scratch/cron/pm-gpu"
+
+mkdir -p $POLARIS_CRON_ROOT
+
+# launch polaris cronjob
+exec bash $HERE/polaris_cron.sh

--- a/cron/polaris_pm-gpu_cron.sh
+++ b/cron/polaris_pm-gpu_cron.sh
@@ -8,4 +8,4 @@ export POLARIS_CRON_ROOT="$PSCRATCH/polaris_scratch/cron/pm-gpu"
 mkdir -p $POLARIS_CRON_ROOT
 
 # launch polaris cronjob
-exec bash $HERE/polaris_cron.sh
+exec bash $HERE/polaris_cron.sh -m pm-gpu


### PR DESCRIPTION
Add cron scripts for Polaris nightly tests.

Polaris nightly tests are being developed for PM-CPU, PM-GPU, Frontier, Chrysalis, and Aurora systems. However, this driver script should remain stable.