### PR TITLE
Add "--driver mct" to some test suites

### DIFF
--- a/jenkins/chrysalis_atmnbfb.sh
+++ b/jenkins/chrysalis_atmnbfb.sh
@@ -5,4 +5,4 @@ export SCRIPTROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
 export CIME_MACHINE=chrysalis
 source $SCRIPTROOT/util/setup_common.sh
 
-$RUNSCRIPT -j 4 -t e3sm_atm_nbfb $RUNSCRIPT_FLAGS -O master --baseline-compare --ignore-memleak --pes-file $E3SMREPO/cime_config/testmods_dirs/config_pes_tests.xml
+$RUNSCRIPT -j 4 -t e3sm_atm_nbfb $RUNSCRIPT_FLAGS --driver mct -O master --baseline-compare --ignore-memleak --pes-file $E3SMREPO/cime_config/testmods_dirs/config_pes_tests.xml

--- a/jenkins/chrysalis_landice.sh
+++ b/jenkins/chrysalis_landice.sh
@@ -5,4 +5,4 @@ export SCRIPTROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
 export CIME_MACHINE=chrysalis
 source $SCRIPTROOT/util/setup_common.sh
 
-$RUNSCRIPT -O master -t e3sm_landice_developer --compiler=gnu $RUNSCRIPT_FLAGS --baseline-compare --ignore-memleak --pes-file $E3SMREPO/cime_config/testmods_dirs/config_pes_tests.xml
+$RUNSCRIPT -O master -t e3sm_landice_developer --compiler=gnu --driver mct $RUNSCRIPT_FLAGS --baseline-compare --ignore-memleak --pes-file $E3SMREPO/cime_config/testmods_dirs/config_pes_tests.xml

--- a/jenkins/chrysalis_nbfb.sh
+++ b/jenkins/chrysalis_nbfb.sh
@@ -5,4 +5,4 @@ export SCRIPTROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
 export CIME_MACHINE=chrysalis
 source $SCRIPTROOT/util/setup_common.sh
 
-$RUNSCRIPT -j 4 -t e3sm_nbfb $RUNSCRIPT_FLAGS -O master --baseline-compare --ignore-memleak --pes-file $E3SMREPO/cime_config/testmods_dirs/config_pes_tests.xml --walltime 02:00:00
+$RUNSCRIPT -j 4 -t e3sm_nbfb $RUNSCRIPT_FLAGS --driver mct -O master --baseline-compare --ignore-memleak --pes-file $E3SMREPO/cime_config/testmods_dirs/config_pes_tests.xml --walltime 02:00:00

--- a/jenkins/pm-cpu_landice.sh
+++ b/jenkins/pm-cpu_landice.sh
@@ -6,4 +6,4 @@ export CIME_MACHINE=pm-cpu
 export SCREAM_MACHINE=$CIME_MACHINE
 source $SCRIPTROOT/util/setup_common.sh
 
-$RUNSCRIPT -t e3sm_landice_developer --compiler=gnu -O master --baseline-compare
+$RUNSCRIPT -t e3sm_landice_developer --compiler=gnu --driver mct -O master --baseline-compare

--- a/jenkins/pm-cpu_nbfb.sh
+++ b/jenkins/pm-cpu_nbfb.sh
@@ -6,4 +6,4 @@ export CIME_MACHINE=pm-cpu
 export SCREAM_MACHINE=$CIME_MACHINE
 source $SCRIPTROOT/util/setup_common.sh
 
-$RUNSCRIPT -t e3sm_nbfb --compiler=intel -O master --baseline-compare --ignore-memleak --walltime 01:30:00
+$RUNSCRIPT -t e3sm_nbfb --compiler=intel --driver mct -O master --baseline-compare --ignore-memleak --walltime 01:30:00


### PR DESCRIPTION
Add "--driver mct" to jenkins scripts for
landice and nbfb test suites.